### PR TITLE
Couple minor bugfixes

### DIFF
--- a/etcd3aio/watch.py
+++ b/etcd3aio/watch.py
@@ -100,8 +100,8 @@ class Watcher(object):
         if self._sender_task:
             return
 
-        async def sender_task(timeout, metadata, run_receiver_fn):
-            async with self._watch_stub.Watch.open(timeout=timeout, metadata=metadata) as stream:
+        async def sender_task(metadata, run_receiver_fn):
+            async with self._watch_stub.Watch.open(metadata=metadata) as stream:
                 while request := await self._request_queue.get():
                     try:
                         await stream.send_message(request)
@@ -112,7 +112,7 @@ class Watcher(object):
                 await stream.end()
 
         self._sender_task = asyncio.get_running_loop().create_task(
-            sender_task(self.timeout, self._metadata, self._run_receiver)
+            sender_task(self._metadata, self._run_receiver)
         )
 
     async def _run_receiver(self, stream):

--- a/etcd3aio/watch.py
+++ b/etcd3aio/watch.py
@@ -109,7 +109,7 @@ class Watcher(object):
                     except grpclib.exceptions.StreamTerminatedError as err:
                         await self._handle_steam_termination(err)
 
-                stream.end()
+                await stream.end()
 
         self._sender_task = asyncio.get_running_loop().create_task(
             sender_task(self.timeout, self._metadata, self._run_receiver)

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ message = Release: {current_version} -> {new_version}
 
 [bumpversion:file:setup.py]
 
-[bumpversion:file:etcd3/__init__.py]
+[bumpversion:file:etcd3aio/__init__.py]
 
 [bdist_wheel]
 universal = 1
@@ -17,5 +17,5 @@ builtins = long
 max-line-length = 100
 
 [coverage:run]
-omit = etcd3/etcdrpc/*
+omit = etcd3aio/etcdrpc/*
 

--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,12 @@ setup(
     author_email='aleksei.gusev@gmail.com',
     url='https://github.com/hron/etcd3aio',
     packages=[
-        'etcd3',
-        'etcd3.etcdrpc',
+        'etcd3aio',
+        'etcd3aio.etcdrpc',
     ],
     package_dir={
-        'etcd3': 'etcd3',
-        'etcd3.etcdrpc': 'etcd3/etcdrpc',
+        'etcd3aio': 'etcd3aio',
+        'etcd3aio.etcdrpc': 'etcd3aio/etcdrpc',
     },
     include_package_data=True,
     install_requires=requirements,


### PR DESCRIPTION
Hi,

Thanks for making the module.
From the ones I've seen, it seem to be the best and most future-proof asyncio client for modern etcd.

Trying to install and use it, bumped into a couple very minor issues though:
- `pip install git+https://github.com/hron/etcd3aio/` fails due to old "etcd3" dir in setup.py
- When watchers terminate, asyncio issues warning about `stream.end()` not being awaited in watch.py.

This PR should address both of the above in separate commits.

Couple other minor things spotted, but not addressed in PR commits:
- When creating this PR, checked CONTRIBUTING.rst, and it seem to be full of references to old python-etcd3 project as well - that doc should probably be either updated or removed.
- "Issues" section is disabled via github admin, likely due to it being default for forks. Not an issue if it's intentional ofc.

Cheers!
